### PR TITLE
Update to Swift 3.1

### DIFF
--- a/Combinatorics.podspec
+++ b/Combinatorics.podspec
@@ -1,14 +1,17 @@
 Pod::Spec.new do |s|
 
   s.name             = "Combinatorics"
-  s.version          = "1.0"
+  s.version          = "1.1"
   s.summary          = "Combinatorics contains functions to generate k-permutations and k-combinations (with or without repetition) of 'n' elements."
   s.description      = "Combinatorics contains static functions to generate k-permutations and k-combinations (in both cases either with or without repetition) of the 'n' elements in an array."
   s.homepage         = "https://github.com/almata/Combinatorics"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { "Albert Mata" => "hello@albertmata.net" }
   s.social_media_url = "http://twitter.com/almata"
-  s.platform         = :ios, "8.0"
-  s.source           = { :git => "https://github.com/almata/Combinatorics.git", :tag => "1.0" }
+  s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.9"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
+  s.source           = { :git => "https://github.com/almata/Combinatorics.git", :tag => "1.1" }
   s.source_files     = "Combinatorics/**/*.{h,m,swift}"
 end

--- a/Combinatorics.xcodeproj/project.pbxproj
+++ b/Combinatorics.xcodeproj/project.pbxproj
@@ -151,9 +151,11 @@
 				TargetAttributes = {
 					405A78BD1D4BB3F9007CE709 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 					};
 					405A78C71D4BB3FA007CE709 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -327,6 +329,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -345,6 +348,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.albertmata.Combinatorics;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -355,6 +359,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.albertmata.CombinatoricsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -365,6 +370,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.albertmata.CombinatoricsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -387,6 +393,7 @@
 				405A78D41D4BB3FA007CE709 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		405A78D51D4BB3FA007CE709 /* Build configuration list for PBXNativeTarget "CombinatoricsTests" */ = {
 			isa = XCConfigurationList;
@@ -395,6 +402,7 @@
 				405A78D71D4BB3FA007CE709 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Combinatorics/Combinatorics.h
+++ b/Combinatorics/Combinatorics.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Albert Mata Guerra. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for Combinatorics.
 FOUNDATION_EXPORT double CombinatoricsVersionNumber;

--- a/Combinatorics/Combinatorics.swift
+++ b/Combinatorics/Combinatorics.swift
@@ -8,78 +8,152 @@
 
 import Foundation
 
+/// Combinatorics contains static functions to generate k-permutations and k-combinations 
+/// (in both cases either with or without repetition) of the n elements in an array.
 public struct Combinatorics {
-    
-    // MARK: - Permutations
-    
-    public static func permutationsWithoutRepetitionFrom<T>(elements: [T], taking: Int) -> [[T]] {
-        guard elements.count >= taking else { return [] }
-        guard elements.count >= taking && taking > 0 else { return [[]] }
-        
-        if taking == 1 {
-            return elements.map {[$0]}
-        }
-        
-        var permutations = [[T]]()
-        for (index, element) in elements.enumerate() {
-            var reducedElements = elements
-            reducedElements.removeAtIndex(index)
-            permutations += permutationsWithoutRepetitionFrom(reducedElements, taking: taking - 1).map {[element] + $0}
-        }
-        
-        return permutations
-    }
-    
-    public static func permutationsWithRepetitionFrom<T>(elements: [T], taking: Int) -> [[T]] {
-        guard elements.count >= 0 && taking > 0 else { return [[]] }
-        
-        if taking == 1 {
-            return elements.map {[$0]}
-        }
-        
-        var permutations = [[T]]()
-        for element in elements {
-            permutations += permutationsWithRepetitionFrom(elements, taking: taking - 1).map {[element] + $0}
-        }
-        
-        return permutations
+
+  // MARK: - Permutations
+
+  /// Given an array of elements and how many of them we are taking, returns an array with all possible permutations
+  /// without repetition. Please note that as repetition is not allowed, taking must always be less or equal to
+  /// `elements.count`.
+  /// Almost by convention, if `taking` is 0, the function will return [[]] (an array with only one possible permutation
+  /// - a permutation with no elements). In a different scenario, if `taking` is bigger than `elements.count` the function
+  /// will return [] (an empty array, so including no permutation at all).
+  ///
+  /// - Parameters:
+  ///   - elements: Array to be permutating.
+  ///   - taking: Picking item count from array.
+  /// - Returns: Returns permutations of elements without repetition.
+  public static func permutationsWithoutRepetitionFrom<T>(_ elements: [T], taking: Int) -> [[T]] {
+    guard elements.count >= taking else { return [] }
+    guard elements.count >= taking && taking > 0 else { return [[]] }
+
+    if taking == 1 {
+      return elements.map {[$0]}
     }
 
-    // MARK: - Combinations
-    
-    public static func combinationsWithoutRepetitionFrom<T>(elements: [T], taking: Int) -> [[T]] {
-        guard elements.count >= taking else { return [] }
-        guard elements.count > 0 && taking > 0 else { return [[]] }
-        
-        if taking == 1 {
-            return elements.map {[$0]}
-        }
-        
-        var combinations = [[T]]()
-        for (index, element) in elements.enumerate() {
-            var reducedElements = elements
-            reducedElements.removeFirst(index + 1)
-            combinations += combinationsWithoutRepetitionFrom(reducedElements, taking: taking - 1).map {[element] + $0}
-        }
-        
-        return combinations
+    var permutations = [[T]]()
+    for (index, element) in elements.enumerated() {
+      var reducedElements = elements
+      reducedElements.remove(at: index)
+      permutations += permutationsWithoutRepetitionFrom(reducedElements, taking: taking - 1).map {[element] + $0}
     }
-    
-    public static func combinationsWithRepetitionFrom<T>(elements: [T], taking: Int) -> [[T]] {
-        guard elements.count >= 0 && taking > 0 else { return [[]] }
-        
-        if taking == 1 {
-            return elements.map {[$0]}
-        }
-        
-        var combinations = [[T]]()
-        var reducedElements = elements
-        for element in elements {
-            combinations += combinationsWithRepetitionFrom(reducedElements, taking: taking - 1).map {[element] + $0}
-            reducedElements.removeFirst()
-        }
-        
-        return combinations
+
+    return permutations
+  }
+
+  /// Given an array of elements and how many of them we are taking, returns an array with all possible permutations
+  /// with repetition. Please note that as repetition is allowed, taking does not need to be less or equal to
+  /// `elements.count`.
+  /// Almost by convention, if `taking` is 0, the function will return [[]] (an array with only one possible permutation
+  /// - a permutation with no elements). In a different scenario, if `taking` is bigger than 0 but elements contains no
+  /// elements, the function will return [] (an empty array, so including no permutation at all).
+  ///
+  /// - Parameters:
+  ///   - elements: Array to be permutating.
+  ///   - taking: Picking item count from array.
+  /// - Returns: Returns permutations of elements with repetition.
+  public static func permutationsWithRepetitionFrom<T>(_ elements: [T], taking: Int) -> [[T]] {
+    guard elements.count >= 0 && taking > 0 else { return [[]] }
+
+    if taking == 1 {
+      return elements.map {[$0]}
     }
-    
+
+    var permutations = [[T]]()
+    for element in elements {
+      permutations += permutationsWithRepetitionFrom(elements, taking: taking - 1).map {[element] + $0}
+    }
+
+    return permutations
+  }
+
+  // MARK: - Combinations
+
+  /// Given an array of elements and how many of them we are taking, returns an array with all possible combinations
+  /// without repetition. Please note that as repetition is not allowed, taking must always be less or equal to
+  /// `elements.count`.
+  /// Almost by convention, if `taking` is 0, the function will return [[]] (an array with only one possible combination
+  /// - a combination with no elements). In a different scenario, if taking is bigger than `elements.count` the function
+  /// will return [] (an empty array, so including no combination at all).
+  ///
+  /// - Parameters:
+  ///   - elements: Array to be combinating.
+  ///   - taking: Picking item count from array
+  /// - Returns: Returns combinations of elements without repetition.
+  public static func combinationsWithoutRepetitionFrom<T>(_ elements: [T], taking: Int) -> [[T]] {
+    guard elements.count >= taking else { return [] }
+    guard elements.count > 0 && taking > 0 else { return [[]] }
+
+    if taking == 1 {
+      return elements.map {[$0]}
+    }
+
+    var combinations = [[T]]()
+    for (index, element) in elements.enumerated() {
+      var reducedElements = elements
+      reducedElements.removeFirst(index + 1)
+      combinations += combinationsWithoutRepetitionFrom(reducedElements, taking: taking - 1).map {[element] + $0}
+    }
+
+    return combinations
+  }
+
+  /// Given an array of elements and how many of them we are taking, returns an array with all possible combinations
+  /// with repetition. Please note that as repetition is allowed, taking does not need to be less or equal to
+  /// `elements.count`.
+  /// Almost by convention, if `taking` is 0, the function will return [[]] (an array with only one possible
+  /// combination - a combination with no elements). In a different scenario, if `taking` is bigger than 0 but
+  /// elements contains no elements, the function will return [] (an empty array, so including no combination at all).
+  ///
+  /// - Parameters:
+  ///   - elements: Array to be combinating.
+  ///   - taking: Picking item count from array
+  /// - Returns: Returns combinations of elements with repetition.
+  public static func combinationsWithRepetitionFrom<T>(_ elements: [T], taking: Int) -> [[T]] {
+    guard elements.count >= 0 && taking > 0 else { return [[]] }
+
+    if taking == 1 {
+      return elements.map {[$0]}
+    }
+
+    var combinations = [[T]]()
+    var reducedElements = elements
+    for element in elements {
+      combinations += combinationsWithRepetitionFrom(reducedElements, taking: taking - 1).map {[element] + $0}
+      reducedElements.removeFirst()
+    }
+
+    return combinations
+  }
+}
+
+extension Array {
+
+  /// Permutates array.
+  ///
+  /// - Parameters:
+  ///   - taking: Picking item count.
+  ///   - withRepetition: Could select an item more than one.
+  /// - Returns: Returns permutations.
+  public func permutations(taking: Int, withRepetition: Bool) -> [Array] {
+    if withRepetition {
+      return Combinatorics.permutationsWithRepetitionFrom(self, taking: taking)
+    }
+    return Combinatorics.permutationsWithoutRepetitionFrom(self, taking: taking)
+  }
+
+  /// Combinates array.
+  ///
+  /// - Parameters:
+  ///   - taking: Picking item count.
+  ///   - withRepetition: Could select an item more than one.
+  /// - Returns: Returns combinations.
+  public func combinations(taking: Int, withRepetition: Bool) -> [Array] {
+    if withRepetition {
+      return Combinatorics.combinationsWithRepetitionFrom(self, taking: taking)
+    }
+    return Combinatorics.combinationsWithoutRepetitionFrom(self, taking: taking)
+  }
 }

--- a/CombinatoricsTests/CombinatoricsTests.swift
+++ b/CombinatoricsTests/CombinatoricsTests.swift
@@ -10,204 +10,247 @@ import XCTest
 @testable import Combinatorics
 
 class CombinatoricsTests: XCTestCase {
-    
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testNumberOfPermutationsWithoutRepetitionFrom() {
-        // n = elements
-        // t = taking
-        // Expected result = n! / (n-r)!
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1], taking: 1).count, 1)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2], taking: 2).count, 2)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3], taking: 3).count, 6)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4], taking: 4).count, 24)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 120)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 120)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 60)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 20)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
-    }
-    
-    func testNumberOfPermutationsWithoutRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([Int](), taking: 0).count, 1)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([Int](), taking: 1).count, 0)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2], taking: 3).count, 0)
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
-    }
-    
-    func testElementsOfPermutationsWithoutRepetitionFrom() {
-        let permutations = Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3], taking: 3)
-        XCTAssert(permutations.contains({$0 == [1, 2, 3]}))
-        XCTAssert(permutations.contains({$0 == [1, 3, 2]}))
-        XCTAssert(permutations.contains({$0 == [2, 1, 3]}))
-        XCTAssert(permutations.contains({$0 == [2, 3, 1]}))
-        XCTAssert(permutations.contains({$0 == [3, 1, 2]}))
-        XCTAssert(permutations.contains({$0 == [3, 2, 1]}))
-    }
-    
-    func testElementsOfPermutationsWithoutRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([Int](), taking: 0)[0], [])
-        XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
-    }
-    
-    func testNumberOfPermutationsWithRepetitionFrom() {
-        // n = elements
-        // t = taking
-        // Expected result = n^r
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1], taking: 1).count, 1)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2], taking: 2).count, 4)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2], taking: 3).count, 8)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3], taking: 3).count, 27)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4], taking: 4).count, 256)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 3125)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 625)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 125)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 25)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
-    }
-    
-    func testNumberOfPermutationsWithRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([Int](), taking: 0).count, 1)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([Int](), taking: 1).count, 0)
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
-    }
-    
-    func testElementsOfPermutationsWithRepetitionFrom() {
-        let permutations = Combinatorics.permutationsWithRepetitionFrom([1, 2, 3], taking: 3)
-        XCTAssert(permutations.contains({$0 == [1, 1, 1]}))
-        XCTAssert(permutations.contains({$0 == [1, 1, 2]}))
-        XCTAssert(permutations.contains({$0 == [1, 1, 3]}))
-        XCTAssert(permutations.contains({$0 == [1, 2, 1]}))
-        XCTAssert(permutations.contains({$0 == [1, 2, 2]}))
-        XCTAssert(permutations.contains({$0 == [1, 2, 3]}))
-        XCTAssert(permutations.contains({$0 == [1, 3, 1]}))
-        XCTAssert(permutations.contains({$0 == [1, 3, 2]}))
-        XCTAssert(permutations.contains({$0 == [1, 3, 3]}))
-        
-        XCTAssert(permutations.contains({$0 == [2, 1, 1]}))
-        XCTAssert(permutations.contains({$0 == [2, 1, 2]}))
-        XCTAssert(permutations.contains({$0 == [2, 1, 3]}))
-        XCTAssert(permutations.contains({$0 == [2, 2, 1]}))
-        XCTAssert(permutations.contains({$0 == [2, 2, 2]}))
-        XCTAssert(permutations.contains({$0 == [2, 2, 3]}))
-        XCTAssert(permutations.contains({$0 == [2, 3, 1]}))
-        XCTAssert(permutations.contains({$0 == [2, 3, 2]}))
-        XCTAssert(permutations.contains({$0 == [2, 3, 3]}))
-        
-        XCTAssert(permutations.contains({$0 == [3, 1, 1]}))
-        XCTAssert(permutations.contains({$0 == [3, 1, 2]}))
-        XCTAssert(permutations.contains({$0 == [3, 1, 3]}))
-        XCTAssert(permutations.contains({$0 == [3, 2, 1]}))
-        XCTAssert(permutations.contains({$0 == [3, 2, 2]}))
-        XCTAssert(permutations.contains({$0 == [3, 2, 3]}))
-        XCTAssert(permutations.contains({$0 == [3, 3, 1]}))
-        XCTAssert(permutations.contains({$0 == [3, 3, 2]}))
-        XCTAssert(permutations.contains({$0 == [3, 3, 3]}))
-    }
-    
-    func testElementsOfPermutationsWithRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([Int](), taking: 0)[0], [])
-        XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
-    }
-    
-    func testNumberOfCombinationsWithoutRepetitionFrom() {
-        // n = elements
-        // t = taking
-        // Expected result = n! / (r! × (n-r)!)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1], taking: 1).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2], taking: 2).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 3).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4], taking: 4).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 5)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 10)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 10)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
-    }
-    
-    func testNumberOfCombinationsWithoutRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([Int](), taking: 0).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([Int](), taking: 1).count, 0)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2], taking: 3).count, 0)
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
-    }
-    
-    func testElementsOfCombinationsWithoutRepetitionFrom() {
-        let combinations1 = Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 3)
-        XCTAssert(combinations1.contains({Set($0) == Set([1, 2, 3])}))
-        let combinations2 = Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 2)
-        XCTAssert(combinations2.contains({Set($0) == Set([1, 2])}))
-        XCTAssert(combinations2.contains({Set($0) == Set([1, 3])}))
-        XCTAssert(combinations2.contains({Set($0) == Set([2, 3])}))
-        let combinations3 = Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 1)
-        XCTAssert(combinations3.contains({Set($0) == Set([1])}))
-        XCTAssert(combinations3.contains({Set($0) == Set([2])}))
-        XCTAssert(combinations3.contains({Set($0) == Set([3])}))
-    }
-    
-    func testElementsOfCombinationsWithoutRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([Int](), taking: 0)[0], [])
-        XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
-    }
 
-    func testNumberOfCombinationsWithRepetitionFrom() {
-        // n = elements
-        // t = taking
-        // Expected result = (n+r-1)! / (r! × (n-1)!)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1], taking: 1).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2], taking: 2).count, 3)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2], taking: 3).count, 4)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 3).count, 10)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4], taking: 4).count, 35)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 126)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 70)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 35)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 15)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
-    }
-    
-    func testNumberOfCombinationsWithRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([Int](), taking: 0).count, 1)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([Int](), taking: 1).count, 0)
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
-    }
-    
-    func testElementsOfCombinationsWithRepetitionFrom() {
-        let combinations1 = Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 3)
-        XCTAssert(combinations1.contains({Set($0) == Set([1, 1, 1])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([1, 1, 2])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([1, 1, 3])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([1, 2, 2])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([1, 2, 3])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([1, 3, 3])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([2, 2, 2])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([2, 2, 3])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([3, 3, 3])}))
-        XCTAssert(combinations1.contains({Set($0) == Set([3, 3, 2])}))
-        let combinations2 = Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 2)
-        XCTAssert(combinations2.contains({Set($0) == Set([1, 1])}))
-        XCTAssert(combinations2.contains({Set($0) == Set([1, 2])}))
-        XCTAssert(combinations2.contains({Set($0) == Set([1, 3])}))
-        XCTAssert(combinations2.contains({Set($0) == Set([2, 2])}))
-        XCTAssert(combinations2.contains({Set($0) == Set([2, 3])}))
-        XCTAssert(combinations2.contains({Set($0) == Set([3, 3])}))
-        let combinations3 = Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 1)
-        XCTAssert(combinations3.contains({Set($0) == Set([1])}))
-        XCTAssert(combinations3.contains({Set($0) == Set([2])}))
-        XCTAssert(combinations3.contains({Set($0) == Set([3])}))
-    }
-    
-    func testElementsOfCombinationsWithRepetitionFromEdgeCases() {
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([Int](), taking: 0)[0], [])
-        XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
-    }
-    
+  override func setUp() {
+    super.setUp()
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+  }
+
+  override func tearDown() {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    super.tearDown()
+  }
+
+  func testNumberOfPermutationsWithoutRepetitionFrom() {
+    // n = elements
+    // t = taking
+    // Expected result = n! / (n-r)!
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1], taking: 1).count, 1)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2], taking: 2).count, 2)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3], taking: 3).count, 6)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4], taking: 4).count, 24)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 120)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 120)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 60)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 20)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
+
+    XCTAssertEqual([1].permutations(taking: 1, withRepetition: false).count, 1)
+    XCTAssertEqual([1, 2].permutations(taking: 2, withRepetition: false).count, 2)
+    XCTAssertEqual([1, 2, 3].permutations(taking: 3, withRepetition: false).count, 6)
+    XCTAssertEqual([1, 2, 3, 4].permutations(taking: 4, withRepetition: false).count, 24)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 5, withRepetition: false).count, 120)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 4, withRepetition: false).count, 120)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 3, withRepetition: false).count, 60)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 2, withRepetition: false).count, 20)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 1, withRepetition: false).count, 5)
+
+  }
+
+  func testNumberOfPermutationsWithoutRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([Int](), taking: 0).count, 1)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([Int](), taking: 1).count, 0)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2], taking: 3).count, 0)
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
+  }
+
+  func testElementsOfPermutationsWithoutRepetitionFrom() {
+    let permutations = Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3], taking: 3)
+    XCTAssert(permutations.contains(where: {$0 == [1, 2, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 3, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 1, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 3, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 1, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 2, 1]}))
+  }
+
+  func testElementsOfPermutationsWithoutRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([Int](), taking: 0)[0], [])
+    XCTAssertEqual(Combinatorics.permutationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
+  }
+
+  func testNumberOfPermutationsWithRepetitionFrom() {
+    // n = elements
+    // t = taking
+    // Expected result = n^r
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1], taking: 1).count, 1)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2], taking: 2).count, 4)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2], taking: 3).count, 8)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3], taking: 3).count, 27)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4], taking: 4).count, 256)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 3125)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 625)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 125)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 25)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
+
+    XCTAssertEqual([1].permutations(taking: 1, withRepetition: true).count, 1)
+    XCTAssertEqual([1, 2].permutations(taking: 2, withRepetition: true).count, 4)
+    XCTAssertEqual([1, 2].permutations(taking: 3, withRepetition: true).count, 8)
+    XCTAssertEqual([1, 2, 3].permutations(taking: 3, withRepetition: true).count, 27)
+    XCTAssertEqual([1, 2, 3, 4].permutations(taking: 4, withRepetition: true).count, 256)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 5, withRepetition: true).count, 3125)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 4, withRepetition: true).count, 625)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 3, withRepetition: true).count, 125)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 2, withRepetition: true).count, 25)
+    XCTAssertEqual([1, 2, 3, 4, 5].permutations(taking: 1, withRepetition: true).count, 5)
+  }
+
+  func testNumberOfPermutationsWithRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([Int](), taking: 0).count, 1)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([Int](), taking: 1).count, 0)
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
+  }
+
+  func testElementsOfPermutationsWithRepetitionFrom() {
+    let permutations = Combinatorics.permutationsWithRepetitionFrom([1, 2, 3], taking: 3)
+    XCTAssert(permutations.contains(where: {$0 == [1, 1, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 1, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 1, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 2, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 2, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 2, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 3, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 3, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [1, 3, 3]}))
+
+    XCTAssert(permutations.contains(where: {$0 == [2, 1, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 1, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 1, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 2, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 2, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 2, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 3, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 3, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [2, 3, 3]}))
+
+    XCTAssert(permutations.contains(where: {$0 == [3, 1, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 1, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 1, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 2, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 2, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 2, 3]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 3, 1]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 3, 2]}))
+    XCTAssert(permutations.contains(where: {$0 == [3, 3, 3]}))
+  }
+
+  func testElementsOfPermutationsWithRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([Int](), taking: 0)[0], [])
+    XCTAssertEqual(Combinatorics.permutationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
+  }
+
+  func testNumberOfCombinationsWithoutRepetitionFrom() {
+    // n = elements
+    // t = taking
+    // Expected result = n! / (r! × (n-r)!)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1], taking: 1).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2], taking: 2).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 3).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4], taking: 4).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 5)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 10)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 10)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
+
+    XCTAssertEqual([1].combinations(taking: 1, withRepetition: false).count, 1)
+    XCTAssertEqual([1, 2].combinations(taking: 2, withRepetition: false).count, 1)
+    XCTAssertEqual([1, 2, 3].combinations(taking: 3, withRepetition: false).count, 1)
+    XCTAssertEqual([1, 2, 3, 4].combinations(taking: 4, withRepetition: false).count, 1)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 5, withRepetition: false).count, 1)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 4, withRepetition: false).count, 5)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 3, withRepetition: false).count, 10)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 2, withRepetition: false).count, 10)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 1, withRepetition: false).count, 5)
+  }
+
+  func testNumberOfCombinationsWithoutRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([Int](), taking: 0).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([Int](), taking: 1).count, 0)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2], taking: 3).count, 0)
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
+  }
+
+  func testElementsOfCombinationsWithoutRepetitionFrom() {
+    let combinations1 = Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 3)
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([1, 2, 3])}))
+    let combinations2 = Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 2)
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([1, 2])}))
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([1, 3])}))
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([2, 3])}))
+    let combinations3 = Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3], taking: 1)
+    XCTAssert(combinations3.contains(where: {Set($0) == Set([1])}))
+    XCTAssert(combinations3.contains(where: {Set($0) == Set([2])}))
+    XCTAssert(combinations3.contains(where: {Set($0) == Set([3])}))
+  }
+
+  func testElementsOfCombinationsWithoutRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([Int](), taking: 0)[0], [])
+    XCTAssertEqual(Combinatorics.combinationsWithoutRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
+  }
+
+  func testNumberOfCombinationsWithRepetitionFrom() {
+    // n = elements
+    // t = taking
+    // Expected result = (n+r-1)! / (r! × (n-1)!)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1], taking: 1).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2], taking: 2).count, 3)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2], taking: 3).count, 4)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 3).count, 10)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4], taking: 4).count, 35)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 5).count, 126)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 4).count, 70)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 3).count, 35)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 2).count, 15)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 1).count, 5)
+
+    XCTAssertEqual([1].combinations(taking: 1, withRepetition: true).count, 1)
+    XCTAssertEqual([1, 2].combinations(taking: 2, withRepetition: true).count, 3)
+    XCTAssertEqual([1, 2].combinations(taking: 3, withRepetition: true).count, 4)
+    XCTAssertEqual([1, 2, 3].combinations(taking: 3, withRepetition: true).count, 10)
+    XCTAssertEqual([1, 2, 3, 4].combinations(taking: 4, withRepetition: true).count, 35)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 5, withRepetition: true).count, 126)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 4, withRepetition: true).count, 70)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 3, withRepetition: true).count, 35)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 2, withRepetition: true).count, 15)
+    XCTAssertEqual([1, 2, 3, 4, 5].combinations(taking: 1, withRepetition: true).count, 5)
+  }
+
+  func testNumberOfCombinationsWithRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([Int](), taking: 0).count, 1)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([Int](), taking: 1).count, 0)
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0).count, 1)
+  }
+
+  func testElementsOfCombinationsWithRepetitionFrom() {
+    let combinations1 = Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 3)
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([1, 1, 1])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([1, 1, 2])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([1, 1, 3])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([1, 2, 2])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([1, 2, 3])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([1, 3, 3])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([2, 2, 2])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([2, 2, 3])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([3, 3, 3])}))
+    XCTAssert(combinations1.contains(where: {Set($0) == Set([3, 3, 2])}))
+    let combinations2 = Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 2)
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([1, 1])}))
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([1, 2])}))
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([1, 3])}))
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([2, 2])}))
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([2, 3])}))
+    XCTAssert(combinations2.contains(where: {Set($0) == Set([3, 3])}))
+    let combinations3 = Combinatorics.combinationsWithRepetitionFrom([1, 2, 3], taking: 1)
+    XCTAssert(combinations3.contains(where: {Set($0) == Set([1])}))
+    XCTAssert(combinations3.contains(where: {Set($0) == Set([2])}))
+    XCTAssert(combinations3.contains(where: {Set($0) == Set([3])}))
+  }
+
+  func testElementsOfCombinationsWithRepetitionFromEdgeCases() {
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([Int](), taking: 0)[0], [])
+    XCTAssertEqual(Combinatorics.combinationsWithRepetitionFrom([1, 2, 3, 4, 5], taking: 0)[0], [])
+  }
+
 }


### PR DESCRIPTION
- Updated Swift 3.1 using xcode converter.
- Added Array extensions for using directly from array types.
Just call [1, 2].permutations(...) or [1, 2].combinations
- Podspec updated to version 1.1
- Added osx, tvos and watchos targets to podspec
- Added documentations.
- Added array extension tests.